### PR TITLE
Update bn.js

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -50,7 +50,7 @@
 
   var Buffer
   try {
-    Buffer = require('buffer').Buffer
+    Buffer = require('buffer/').Buffer
   } catch (e) {
   }
 


### PR DESCRIPTION
To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!