### PR TITLE
Module parse failed: Duplicate export 'default'

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,4 +72,4 @@ bsv.Message = require('./lib/message/message')
 bsv.Mnemonic = require('./lib/mnemonic/mnemonic')
 
 module.exports = bsv
-export default bsv
+// export default bsv


### PR DESCRIPTION
We have a install error at /@scrypt-inc/bsv/dist/module.js
Module parse failed: Duplicate export 'default'

Fixed it